### PR TITLE
Clearer file destinations.

### DIFF
--- a/docs/content/configuration/defaults.md
+++ b/docs/content/configuration/defaults.md
@@ -5,6 +5,9 @@ title: Default settings
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
 <!-- spellchecker-disable -->
+
+Configure ansible-later using a `.later.yml` file or [globally](/configuration).
+
 {{< highlight YAML "linenos=table" >}}
 ---
 ansible:


### PR DESCRIPTION
I needed to read quite a bit to understand that the filename is `.later.yml`. This line should help startes (like myself) to configure ansible-later quicker.