### PR TITLE
fix: add 'always' to allowed prevlines for CheckTaskSeparation

### DIFF
--- a/ansiblelater/rules/CheckTaskSeparation.py
+++ b/ansiblelater/rules/CheckTaskSeparation.py
@@ -23,7 +23,9 @@ class CheckTaskSeparation(StandardBase):
         task_regex = re.compile(r"-\sname:(.*)")
         prevline = "#file_start_marker"
 
-        allowed_prevline = ["---", "tasks:", "pre_tasks:", "post_tasks:", "block:", "rescue:"]
+        allowed_prevline = [
+            "---", "tasks:", "pre_tasks:", "post_tasks:", "block:", "rescue:", "always:"
+        ]
 
         errors = task_errors + line_errors
         if not errors:


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/ansible-later/issues/239