### PR TITLE
fix: add 'handlers' to allowed prevlines for CheckTaskSeparation

### DIFF
--- a/ansiblelater/rules/CheckTaskSeparation.py
+++ b/ansiblelater/rules/CheckTaskSeparation.py
@@ -24,7 +24,14 @@ class CheckTaskSeparation(StandardBase):
         prevline = "#file_start_marker"
 
         allowed_prevline = [
-            "---", "tasks:", "pre_tasks:", "post_tasks:", "block:", "rescue:", "always:"
+            "---",
+            "handlers:",
+            "tasks:",
+            "pre_tasks:",
+            "post_tasks:",
+            "block:",
+            "rescue:",
+            "always:",
         ]
 
         errors = task_errors + line_errors


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/ansible-later/issues/248