### PR TITLE
fix: replace potential regex syntax used in filters

### DIFF
--- a/ansiblelater/rules/CheckFilterSeparation.py
+++ b/ansiblelater/rules/CheckFilterSeparation.py
@@ -23,6 +23,8 @@ class CheckFilterSeparation(StandardBase):
                 match = braces.findall(line)
                 if match:
                     for item in match:
+                        # replace potential regex in filters
+                        item = re.sub(r"\(.+\)", "(dummy)", line)
                         matches.append((i, item))
 
             for i, line in matches:


### PR DESCRIPTION
Strip out content between brackets as it could contain, e.g. regex syntax with pipes `|`. This will lead to false positive results of the `CheckFilterSeparation` rule.