### PR TITLE
Pre commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+---
+- id: ansible-later
+  name: ansible-later
+  description: Run ansible-later, a best-practice scanner for Ansible.
+  entry: ansible-later
+  language: python
+  pass_filenames: True
+  always_run: True
+  additional_dependencies:
+    - ansible

--- a/docs/content/usage/pre-commit.md
+++ b/docs/content/usage/pre-commit.md
@@ -1,0 +1,20 @@
+---
+title: Pre-Commit
+---
+
+ansible-later can be used with the [pre-commit][pre-commit] framework:
+
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- spellchecker-disable -->
+{{< highlight yaml "linenos=table" >}}
+- repo: https://github.com/thegeeklab/ansible-later
+  rev: v3.0.2  # or whatever tag you want
+  hooks:
+    - id: ansible-later
+{{< /highlight >}}
+<!-- spellchecker-enable -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+[pre-commit]: https://pre-commit.com/


### PR DESCRIPTION
This adds a `.pre-commit-hooks.yaml` file so that others can use this via the [`pre-commit`](https://pre-commit.com) framework.

I've also added docs for this. I'm not familiar with your doc system to let me know if there's other stuff I need to update.

Closes #514.