### PR TITLE
fix: improve url and jinja string escapes

### DIFF
--- a/ansiblelater/rules/CheckCommandInsteadOfModule.py
+++ b/ansiblelater/rules/CheckCommandInsteadOfModule.py
@@ -39,9 +39,12 @@ class CheckCommandInsteadOfModule(StandardBase):
                 if task["action"]["__ansible_module__"] in commands:
                     first_cmd_arg = self.get_first_cmd_arg(task)
                     executable = os.path.basename(first_cmd_arg)
+                    cmd = cmd = self.get_safe_cmd(task)
+
                     if (
                         first_cmd_arg and executable in modules
                         and task["action"].get("warn", True) and "register" not in task
+                        and not any(ch in cmd for ch in self.SHELL_PIPE_CHARS)
                     ):
                         errors.append(
                             self.Error(

--- a/ansiblelater/rules/CheckShellInsteadCommand.py
+++ b/ansiblelater/rules/CheckShellInsteadCommand.py
@@ -1,5 +1,3 @@
-import re
-
 from ansiblelater.standard import StandardBase
 
 
@@ -22,13 +20,8 @@ class CheckShellInsteadCommand(StandardBase):
                     if "executable" in task["action"]:
                         continue
 
-                    if "cmd" in task["action"]:
-                        cmd = task["action"].get("cmd", [])
-                    else:
-                        cmd = " ".join(task["action"].get("__ansible_arguments__", []))
-
-                    unjinja = re.sub(r"\{\{[^\}]*\}\}", "JINJA_VAR", cmd)
-                    if not any(ch in unjinja for ch in "&|<>;$\n*[]{}?"):
+                    cmd = self.get_safe_cmd(task)
+                    if not any(ch in cmd for ch in self.SHELL_PIPE_CHARS):
                         errors.append(self.Error(task["__line__"], self.helptext))
 
         return self.Result(candidate.path, errors)


### PR DESCRIPTION
Fixes: https://github.com/thegeeklab/ansible-later/issues/582

Adds a method to get a "safe" cmd from task. The method replaces URLs and Jinja strings with a placeholder to avoid issues in `shell` and `command` module related rules. 