### PR TITLE
fix: call init_plugin_loader to fix module loading during arg parse

### DIFF
--- a/ansiblelater/utils/yamlhelper.py
+++ b/ansiblelater/utils/yamlhelper.py
@@ -69,7 +69,8 @@ def ansible_template(basedir, varname, templatevars, **kwargs):
 try:
     from ansible.plugins import module_loader
 except ImportError:
-    from ansible.plugins.loader import module_loader
+    from ansible.plugins.loader import init_plugin_loader, module_loader
+    init_plugin_loader()
 
 LINE_NUMBER_KEY = "__line__"
 FILENAME_KEY = "__file__"
@@ -411,7 +412,7 @@ def normalize_task(task, filename, custom_modules=None):
     try:
         action, arguments, normalized["delegate_to"] = mod_arg_parser.parse()
     except AnsibleParserError as e:
-        raise LaterAnsibleError("syntax error", e) from e
+        raise LaterAnsibleError(e) from e
 
     # denormalize shell -> command conversion
     if "_uses_shell" in arguments:


### PR DESCRIPTION
Ref: https://github.com/ansible/ansible/pull/78915

```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib64/python3.11/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
           ^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/ansiblelater/__main__.py", line 98, in _review_wrapper
    return candidate.review()
           ^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/ansiblelater/candidate.py", line 98, in review
    result = standard.check(self, self.config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/ansiblelater/rules/CheckBecomeUser.py", line 13, in check
    tasks, errors = self.get_normalized_tasks(candidate, settings)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/ansiblelater/standard.py", line 156, in get_normalized_tasks
    normalize_task(
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/ansiblelater/utils/yamlhelper.py", line 413, in normalize_task
    action, arguments, normalized["delegate_to"] = mod_arg_parser.parse()
                                                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/.venv/lib/python3.11/site-packages/ansible/parsing/mod_args.py", line 307, in parse
    context = action_loader.find_plugin_with_context(item, collection_list=self._collection_list)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/.venv/lib/python3.11/site-packages/ansible/plugins/loader.py", line 586, in find_plugin_with_context
    result = self._resolve_plugin_step(name, mod_type, ignore_deprecated, check_aliases, collection_list, plugin_load_context=plugin_load_context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/.venv/lib/python3.11/site-packages/ansible/plugins/loader.py", line 682, in _resolve_plugin_step
    return self._find_plugin_legacy(name, plugin_load_context, ignore_deprecated, check_aliases, suffix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/.venv/lib/python3.11/site-packages/ansible/plugins/loader.py", line 787, in _find_plugin_legacy
    return self._find_fq_plugin(fq_name=candidate_fqcr, extension=suffix, plugin_load_context=plugin_load_context, ignore_deprecated=ignore_deprecated)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/.venv/lib/python3.11/site-packages/ansible/plugins/loader.py", line 476, in _find_fq_plugin
    routing_metadata = self._query_collection_routing_meta(acr, plugin_type, extension=extension)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/.venv/lib/python3.11/site-packages/ansible/plugins/loader.py", line 434, in _query_collection_routing_meta
    collection_pkg = import_module(acr.n_python_collection_package_name)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1142, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'ansible_collections.ansible.builtin'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/rknet/rkau2905/Devel/private/python/ansible-later/ansiblelater/__main__.py", line 88, in main
    errors = (sum(p.map(_review_wrapper, tasks)))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/multiprocessing/pool.py", line 367, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/multiprocessing/pool.py", line 774, in get
    raise self._value
ModuleNotFoundError: No module named 'ansible_collections.ansible.builtin'
```