### PR TITLE
fix: use poetry-dynamic-versioning for PEP 517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ filterwarnings = [
 omit = ["**/test/*"]
 
 [build-system]
-build-backend = "poetry.core.masonry.api"
+build-backend = "poetry_dynamic_versioning.backend"
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 
 [tool.ruff]


### PR DESCRIPTION
The same context as https://github.com/thegeeklab/ansible-doctor/pull/541.