### PR TITLE
fix: ensure yaml document end marker is not set

### DIFF
--- a/ansiblelater/rules/CheckYamlDocumentEnd.py
+++ b/ansiblelater/rules/CheckYamlDocumentEnd.py
@@ -3,7 +3,7 @@ from ansiblelater.rule import RuleBase
 
 class CheckYamlDocumentEnd(RuleBase):
     rid = "YML109"
-    description = "YAML should contain document end marker"
+    description = "YAML document end marker should match configuration"
     types = ["playbook", "task", "handler", "rolevars", "hostvars", "groupvars", "meta"]
 
     def check(self, candidate, settings):

--- a/ansiblelater/rules/CheckYamlDocumentStart.py
+++ b/ansiblelater/rules/CheckYamlDocumentStart.py
@@ -3,7 +3,7 @@ from ansiblelater.rule import RuleBase
 
 class CheckYamlDocumentStart(RuleBase):
     rid = "YML104"
-    description = "YAML should contain document start marker"
+    description = "YAML document start marker should match configuration"
     types = ["playbook", "task", "handler", "rolevars", "hostvars", "groupvars", "meta"]
 
     def check(self, candidate, settings):

--- a/ansiblelater/rules/CheckYamlOctalValues.py
+++ b/ansiblelater/rules/CheckYamlOctalValues.py
@@ -3,7 +3,7 @@ from ansiblelater.rule import RuleBase
 
 class CheckYamlOctalValues(RuleBase):
     rid = "YML110"
-    description = "YAML should not use forbidden implicit or explicit octal value"
+    description = "YAML implicit/explicit octal value should match configuration"
     types = ["playbook", "task", "handler", "rolevars", "hostvars", "groupvars", "meta"]
 
     def check(self, candidate, settings):

--- a/ansiblelater/settings.py
+++ b/ansiblelater/settings.py
@@ -174,7 +174,7 @@ class Settings:
                     "present": True,
                 },
                 "document-end": {
-                    "present": True,
+                    "present": False,
                 },
                 "colons": {
                     "max-spaces-before": 0,


### PR DESCRIPTION
BREAKING CHANGE: The default setting for the yamllint rule `docuent-end` has been changed to `false`.